### PR TITLE
Forgot the padding for the menu in gtkrc

### DIFF
--- a/themes/Ghomix/gtk-2.0/gtkrc
+++ b/themes/Ghomix/gtk-2.0/gtkrc
@@ -26,10 +26,10 @@ style "murrine-default" {
 
 	GtkImage::x-ayatana-indicator-dynamic = 1
 
-	GtkMenu::horizontal-padding = 0
-	GtkMenu::vertical-padding = 0
+	GtkMenu::horizontal-padding = 3
+	GtkMenu::vertical-padding = 3
 
-	GtkMenuBar::internal-padding = 0
+	GtkMenuBar::internal-padding = 3
 	GtkMenuBar::window-dragging = 1
 
 	GtkMenuItem::arrow-scaling= 0.5


### PR DESCRIPTION
I forgot that the padding for the menu items was changed in the gtkrc.
